### PR TITLE
Updates PHPMailer for WP 5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The sources are updated when needed, so there may be minor differences between t
 
 This library should be installed as a Composer dependency inside your plugin or theme:
 
-    $ composer require --dev rask/wp-test-framework
+    $ composer require --dev msaari/wp-test-framework
     
 ### WordPress testing installation setup
 
@@ -34,7 +34,7 @@ Inside your plugin/theme directory you need to setup PHPUnit. Any regular-ish `p
     
     require_once './vendor/autoload.php';
     
-    \rask\WpTestFramework\Framework::load();
+    \msaari\WpTestFramework\Framework::load();
 
 Then you should load your plugin or theme. In the same bootstrap file you can do the following:
 
@@ -42,7 +42,7 @@ Then you should load your plugin or theme. In the same bootstrap file you can do
     
     require_once './vendor/autoload.php';
     
-    \rask\WpTestFramework\Framework::load();
+    \msaari\WpTestFramework\Framework::load();
     
     // Load your plugin
     

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rask/wp-test-framework
+# msaari/wp-test-framework
 
 Extracted and librarized version of WordPress core's PHPUnit test framework to help with writing integration tests in WordPress plugins and themes.
 

--- a/composer.json
+++ b/composer.json
@@ -1,16 +1,16 @@
 {
-    "name": "rask/wp-test-framework",
+    "name": "msaari/wp-test-framework",
     "description": "Extracted library from WordPress PHPUnit framework to aid in integration testing of plugins and themes",
     "type": "library",
     "keywords": ["wordpress", "testing", "tests", "phpunit"],
     "license": "GPL-3.0-or-later",
     "support": {
-        "source": "https://github.com/rask/wp-test-framework"
+        "source": "https://github.com/msaari/wp-test-framework"
     },
 
     "autoload": {
         "psr-4": {
-            "rask\\WpTestFramework\\": "src/"
+            "msaari\\WpTestFramework\\": "src/"
         }
     },
 

--- a/src/phpunit/includes/install.php
+++ b/src/phpunit/includes/install.php
@@ -24,7 +24,6 @@ $PHP_SELF = $GLOBALS['PHP_SELF'] = $_SERVER['PHP_SELF'] = '/index.php';
 
 tests_add_filter( 'wp_die_handler', '_wp_die_handler_filter_exit' );
 
-define( 'WP_REPAIRING', true );
 require_once ABSPATH . '/wp-settings.php';
 
 require_once ABSPATH . '/wp-admin/includes/upgrade.php';

--- a/src/phpunit/includes/install.php
+++ b/src/phpunit/includes/install.php
@@ -24,6 +24,7 @@ $PHP_SELF = $GLOBALS['PHP_SELF'] = $_SERVER['PHP_SELF'] = '/index.php';
 
 tests_add_filter( 'wp_die_handler', '_wp_die_handler_filter_exit' );
 
+define( 'WP_REPAIRING', true );
 require_once ABSPATH . '/wp-settings.php';
 
 require_once ABSPATH . '/wp-admin/includes/upgrade.php';

--- a/src/phpunit/includes/mock-mailer.php
+++ b/src/phpunit/includes/mock-mailer.php
@@ -1,7 +1,16 @@
 <?php
-require_once( ABSPATH . '/wp-includes/class-phpmailer.php' );
+global $wp_version;
 
-class MockPHPMailer extends PHPMailer {
+if ( version_compare( $wp_version, '5.5', '>=' ) ) {
+	require_once ABSPATH . '/wp-includes/PHPMailer/PHPMailer.php';
+	class MailerClass extends PHPMailer\PHPMailer\PHPMailer {}
+} else {
+	require_once ABSPATH . '/wp-includes/class-phpmailer.php';
+	class MailerClass extends PHPMailer {}
+}
+
+class MockPHPMailer extends MailerClass {
+
 	var $mock_sent = array();
 
 	function preSend() {


### PR DESCRIPTION
WP 5.5 deprecates the old PHPMailer location and moves the class to a different file and separate namespace. This fix uses the correct PHPMailer class depending on the WP version to get rid of the deprecation notice.